### PR TITLE
Update TableMapReduceUtil.java

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
@@ -546,7 +546,7 @@ public class TableMapReduceUtil {
    * @return The scan saved in a Base64 encoded string.
    * @throws IOException When writing the scan fails.
    */
-  static String convertScanToString(Scan scan) throws IOException {
+  public static String convertScanToString(Scan scan) throws IOException {
     ClientProtos.Scan proto = ProtobufUtil.toScan(scan);
     return Base64.encodeBytes(proto.toByteArray());
   }
@@ -558,7 +558,7 @@ public class TableMapReduceUtil {
    * @return The newly created Scan instance.
    * @throws IOException When reading the scan instance fails.
    */
-  static Scan convertStringToScan(String base64) throws IOException {
+  public static Scan convertStringToScan(String base64) throws IOException {
     byte [] decoded = Base64.decode(base64);
     ClientProtos.Scan scan;
     try {


### PR DESCRIPTION
TableMapReduceUtil is an utility class. I can't get it why these handy methods convertStringToScan and convertScanToString are package protected? 

We need to setup server side filters for mapreduce jobs so we must provide a scan object to TableInputFormat and we need those methods to put it into the job configuration. It just does not make sense.
